### PR TITLE
Make 5.2.0 the default version

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ Set this to select or pin to a specific version of jemalloc. The default is to
 use the latest stable version if this is not set. You will receive an error
 mentioning tar if the version does not exist.
 
-**Default**: `5.1.0`
+**Default**: `5.2.0`
 
 **note:** This setting is only used during slug compilation. Changing it will
 require a code change to be deployed in order to take affect.

--- a/bin/compile
+++ b/bin/compile
@@ -8,7 +8,7 @@ CACHE_DIR=$2
 ENV_DIR=$3
 
 # Default version
-version="5.0.1"
+version="5.2.0"
 
 # Read version from configured JEMALLOC_VERSION
 if [ -f $ENV_DIR/JEMALLOC_VERSION ]; then


### PR DESCRIPTION
More exprimentation on different apps has found that 5.2.0 works on Ruby 2.5 and 2.6, regardless of NodeJS version. So we are bumping the default version to 5.2.0.

Thanks to @jmreid for his investigation into this.