### PR TITLE
Revert "Make 5.2.0 the default version"

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ Set this to select or pin to a specific version of jemalloc. The default is to
 use the latest stable version if this is not set. You will receive an error
 mentioning tar if the version does not exist.
 
-**Default**: `5.2.0`
+**Default**: `5.1.0`
 
 **note:** This setting is only used during slug compilation. Changing it will
 require a code change to be deployed in order to take affect.

--- a/bin/compile
+++ b/bin/compile
@@ -8,7 +8,7 @@ CACHE_DIR=$2
 ENV_DIR=$3
 
 # Default version
-version="5.2.0"
+version="5.0.1"
 
 # Read version from configured JEMALLOC_VERSION
 if [ -f $ENV_DIR/JEMALLOC_VERSION ]; then


### PR DESCRIPTION
We have observed some apps that were running fine with 5.0.1 break due to this change, so reverting until we find a better solution.

Sample backtrace from a failing app:

```
Loading environment specific secrets from /app/config/secrets.production.ejson
767: unexpected token at 'node[170]: pthread_create: Invalid argument
["ok"]'
/app/vendor/ruby-2.6.2/lib/ruby/2.6.0/json/common.rb:156:in `parse'
/app/vendor/ruby-2.6.2/lib/ruby/2.6.0/json/common.rb:156:in `parse'
/app/vendor/bundle/ruby/2.6.0/gems/execjs-2.7.0/lib/execjs/external_runtime.rb:68:in `extract_result'
/app/vendor/bundle/ruby/2.6.0/gems/execjs-2.7.0/lib/execjs/external_runtime.rb:39:in `exec'
```

Full conversation here: https://shopify.slack.com/archives/C165TG7S7/p1566332802317400

Reverts Shopify/heroku-buildpack-jemalloc#1